### PR TITLE
Fix static_store with relative paths

### DIFF
--- a/src/static_store.rs
+++ b/src/static_store.rs
@@ -17,7 +17,7 @@ impl StaticStore {
     fn find(&self, path: &str) -> Option<&[u8]> {
         let found =
             self.mem.iter()
-                    .filter(|&&(s, _)| s == path.as_bytes())
+                    .filter(|&&(s, _)| Path::new(s).ends_with_path(&Path::new(path)))
                     .nth(0);
         match found {
             Some(&(_, bytes)) => Some(bytes),


### PR DESCRIPTION
Fixes two issues:
- The first element when you call `resource_package!` is a `Path`, which can be either a `posix::Path` or a `windows::Path` depending on the compilation platform (this is due to technical reasons)
- People may want to call `resource_package!(../../my_resources/*)`, in which case all the paths would start with `../../` ; that's why you need `ends_with_path` instead of a simple comparaison
