### PR TITLE
Removed native dependencies from readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,6 @@
 A unified method for easily reading and caching files over the filesystem
 and network.
 
-Native dependencies:
-* libcurl3-dev
-
 Calls to `load()` process asynchronously, so it is possible to load files
 from different sources in parallel.
 


### PR DESCRIPTION
libcurl is no longer needed, as we've switched to hyper.
